### PR TITLE
security hardening and fix gosec warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,11 @@ Here's what you can expect from aws-vault
 | `aws-vault exec bar-role2`               | session-token + role + role | session-token | Yes |
 | `aws-vault exec bar-role2 --no-session`  | role + role                 | role          | Yes |
 
+## Security
+It is a good practice to write protect your ~/.aws/config and ~/aws/credentials file as they can include commands that are executed when logging in with the aws cli or aws-vault.
+```bash
+chmod go-w ~/.aws/config ~/.aws/credentials
+```
 ## Development
 
 The [macOS release builds](https://github.com/99designs/aws-vault/releases) are code-signed to avoid extra prompts in Keychain. You can verify this with:

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -6,12 +6,13 @@ import (
 	"fmt"
 	"log"
 	"os"
-	osexec "os/exec"
 	"os/signal"
 	"runtime"
 	"strings"
 	"syscall"
 	"time"
+
+	osexec "golang.org/x/sys/execabs"
 
 	"github.com/99designs/aws-vault/v6/iso8601"
 	"github.com/99designs/aws-vault/v6/server"

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -350,5 +350,8 @@ func execSyscall(command string, args []string, env []string) error {
 	argv = append(argv, command)
 	argv = append(argv, args...)
 
+	/* #nosec G204 */
+	// It is the users explicit intention to execute the command by passing it into `aws-vault exec`
+	// pulled from the aws/config file
 	return syscall.Exec(argv0, argv, env)
 }

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -302,6 +302,8 @@ func (e *environ) Set(key, val string) {
 func execCmd(command string, args []string, env []string) error {
 	log.Printf("Starting child process: %s %s", command, strings.Join(args, " "))
 
+	/* #nosec G204 */
+	// It is the users explicit intention to execute the command by passing it into `aws-vault exec`
 	cmd := osexec.Command(command, args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
@@ -352,6 +354,5 @@ func execSyscall(command string, args []string, env []string) error {
 
 	/* #nosec G204 */
 	// It is the users explicit intention to execute the command by passing it into `aws-vault exec`
-	// pulled from the aws/config file
 	return syscall.Exec(argv0, argv, env)
 }

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/smartystreets/goconvey v1.6.4 // indirect
 	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a
-	golang.org/x/sys v0.0.0-20210521203332-0cec03c779c1 // indirect
+	golang.org/x/sys v0.0.0-20210521203332-0cec03c779c1
 	golang.org/x/term v0.0.0-20210503060354-a79de5458b56
 	gopkg.in/ini.v1 v1.62.0
 )

--- a/prompt/kdialog.go
+++ b/prompt/kdialog.go
@@ -1,8 +1,9 @@
 package prompt
 
 import (
-	"os/exec"
 	"strings"
+
+	exec "golang.org/x/sys/execabs"
 )
 
 func KDialogMfaPrompt(mfaSerial string) (string, error) {

--- a/prompt/kdialog.go
+++ b/prompt/kdialog.go
@@ -7,6 +7,7 @@ import (
 )
 
 func KDialogMfaPrompt(mfaSerial string) (string, error) {
+	/* #nosec G204 */
 	cmd := exec.Command("kdialog", "--inputbox", mfaPromptMessage(mfaSerial), "--title", "aws-vault")
 
 	out, err := cmd.Output()

--- a/prompt/osascript.go
+++ b/prompt/osascript.go
@@ -1,12 +1,16 @@
 package prompt
 
 import (
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
 )
 
 func OSAScriptMfaPrompt(mfaSerial string) (string, error) {
+	if !validateMfaName(mfaSerial) {
+		return "", errors.New(fmt.Sprintf("Invalid Mfa serial name %s.", mfaSerial))
+	}
 	cmd := exec.Command("osascript", "-e", fmt.Sprintf(`
 		display dialog "%s" default answer "" buttons {"OK", "Cancel"} default button 1
         text returned of the result

--- a/prompt/osascript.go
+++ b/prompt/osascript.go
@@ -11,6 +11,8 @@ func OSAScriptMfaPrompt(mfaSerial string) (string, error) {
 	if !validateMfaName(mfaSerial) {
 		return "", errors.New(fmt.Sprintf("Invalid Mfa serial name %s.", mfaSerial))
 	}
+	/* #nosec G204 */
+	// user input is restricted to alpha-numeric+=/:,.+
 	cmd := exec.Command("osascript", "-e", fmt.Sprintf(`
 		display dialog "%s" default answer "" buttons {"OK", "Cancel"} default button 1
         text returned of the result

--- a/prompt/osascript.go
+++ b/prompt/osascript.go
@@ -1,20 +1,17 @@
 package prompt
 
 import (
-	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
 )
 
 func OSAScriptMfaPrompt(mfaSerial string) (string, error) {
-	if !validateMfaName(mfaSerial) {
-		return "", errors.New(fmt.Sprintf("Invalid Mfa serial name %s.", mfaSerial))
-	}
 	/* #nosec G204 */
-	// user input is restricted to alpha-numeric+=/:,.+
+	// command is static
+	// user input is sanitized for osascript context using %q
 	cmd := exec.Command("osascript", "-e", fmt.Sprintf(`
-		display dialog "%s" default answer "" buttons {"OK", "Cancel"} default button 1
+		display dialog %q default answer "" buttons {"OK", "Cancel"} default button 1
         text returned of the result
         return result`,
 		mfaPromptMessage(mfaSerial)))

--- a/prompt/passotp.go
+++ b/prompt/passotp.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
 	"strings"
+
+	exec "golang.org/x/sys/execabs"
 )
 
 // PassOTPProvider uses the pass otp extension to generate a OATH-TOTP token

--- a/prompt/passotp.go
+++ b/prompt/passotp.go
@@ -19,6 +19,7 @@ func PassMfaProvider(mfaSerial string) (string, error) {
 	}
 
 	log.Printf("Fetching MFA code using `pass otp %s`", passOathCredName)
+	/* #nosec G204 */
 	cmd := exec.Command("pass", "otp", passOathCredName)
 	cmd.Stderr = os.Stderr
 

--- a/prompt/prompt.go
+++ b/prompt/prompt.go
@@ -2,6 +2,7 @@ package prompt
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 )
 
@@ -24,6 +25,15 @@ func Method(s string) PromptFunc {
 		panic(fmt.Sprintf("Prompt method %q doesn't exist", s))
 	}
 	return m
+}
+
+// names supported AWS MFA serial names
+// see https://docs.aws.amazon.com/cli/latest/reference/iam/create-virtual-mfa-device.html#options
+// --virtual-mfa-device-name for restrictions
+var isValidMfaSerial = regexp.MustCompile(`^[a-zA-Z0-9+=/:,.+]+$`).MatchString
+
+func validateMfaName(mfaSerial string) bool {
+	return isValidMfaSerial(mfaSerial)
 }
 
 func mfaPromptMessage(mfaSerial string) string {

--- a/prompt/prompt.go
+++ b/prompt/prompt.go
@@ -2,7 +2,6 @@ package prompt
 
 import (
 	"fmt"
-	"regexp"
 	"sort"
 )
 
@@ -25,15 +24,6 @@ func Method(s string) PromptFunc {
 		panic(fmt.Sprintf("Prompt method %q doesn't exist", s))
 	}
 	return m
-}
-
-// names supported AWS MFA serial names
-// see https://docs.aws.amazon.com/cli/latest/reference/iam/create-virtual-mfa-device.html#options
-// --virtual-mfa-device-name for restrictions
-var isValidMfaSerial = regexp.MustCompile(`^[a-zA-Z0-9+=/:,.+]+$`).MatchString
-
-func validateMfaName(mfaSerial string) bool {
-	return isValidMfaSerial(mfaSerial)
 }
 
 func mfaPromptMessage(mfaSerial string) string {

--- a/prompt/ykman.go
+++ b/prompt/ykman.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
 	"strings"
+
+	exec "golang.org/x/sys/execabs"
 )
 
 // YkmanProvider runs ykman to generate a OATH-TOTP token from the Yubikey device

--- a/prompt/ykman.go
+++ b/prompt/ykman.go
@@ -36,6 +36,9 @@ func YkmanMfaProvider(mfaSerial string) (string, error) {
 	}
 
 	log.Printf("Fetching MFA code using `ykman %s`", strings.Join(args, " "))
+	/* #nosec G204 */
+	// command name is hardcoded
+	// no shell expansion occurs
 	cmd := exec.Command("ykman", args...)
 	cmd.Stderr = os.Stderr
 

--- a/prompt/zenity.go
+++ b/prompt/zenity.go
@@ -1,8 +1,9 @@
 package prompt
 
 import (
-	"os/exec"
 	"strings"
+
+	exec "golang.org/x/sys/execabs"
 )
 
 func ZenityMfaPrompt(mfaSerial string) (string, error) {

--- a/prompt/zenity.go
+++ b/prompt/zenity.go
@@ -7,6 +7,7 @@ import (
 )
 
 func ZenityMfaPrompt(mfaSerial string) (string, error) {
+	/* #nosec G204 */
 	cmd := exec.Command("zenity", "--entry", "--title", "aws-vault", "--text", mfaPromptMessage(mfaSerial))
 
 	out, err := cmd.Output()

--- a/server/ec2alias_windows.go
+++ b/server/ec2alias_windows.go
@@ -4,7 +4,7 @@ package server
 
 import (
 	"fmt"
-	"os/exec"
+	exec "golang.org/x/sys/execabs"
 	"strings"
 )
 

--- a/server/ec2proxy_default.go
+++ b/server/ec2proxy_default.go
@@ -4,9 +4,9 @@ package server
 
 import (
 	"errors"
+	exec "golang.org/x/sys/execabs"
 	"log"
 	"os"
-	"os/exec"
 	"time"
 )
 

--- a/server/ec2proxy_unix.go
+++ b/server/ec2proxy_unix.go
@@ -11,6 +11,8 @@ import (
 // StartEc2EndpointProxyServerProcess starts a `aws-vault proxy` process
 func StartEc2EndpointProxyServerProcess() error {
 	log.Println("Starting `aws-vault proxy` as root in the background")
+	/* #nosec */
+	// Always resolves to aws-vault executable
 	cmd := exec.Command("sudo", "-b", awsVaultExecutable(), "proxy")
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout

--- a/server/ec2proxy_unix.go
+++ b/server/ec2proxy_unix.go
@@ -11,7 +11,7 @@ import (
 // StartEc2EndpointProxyServerProcess starts a `aws-vault proxy` process
 func StartEc2EndpointProxyServerProcess() error {
 	log.Println("Starting `aws-vault proxy` as root in the background")
-	/* #nosec */
+	/* #nosec G204 */
 	// Always resolves to aws-vault executable
 	cmd := exec.Command("sudo", "-b", awsVaultExecutable(), "proxy")
 	cmd.Stdin = os.Stdin

--- a/vault/assumerolewithwebidentityprovider.go
+++ b/vault/assumerolewithwebidentityprovider.go
@@ -6,12 +6,13 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"os/exec"
-	"runtime"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	exec "golang.org/x/sys/execabs"
+
 	ststypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
 )
 
@@ -86,12 +87,7 @@ func (p *AssumeRoleWithWebIdentityProvider) webIdentityToken() (string, error) {
 	}
 
 	// Exec WebIdentityTokenProcess to retrieve OpenID Connect token
-	var cmdArgs []string
-	if runtime.GOOS == "windows" {
-		cmdArgs = []string{"cmd.exe", "/C", p.WebIdentityTokenProcess}
-	} else {
-		cmdArgs = []string{"/bin/sh", "-c", p.WebIdentityTokenProcess}
-	}
+	var cmdArgs []string = strings.Fields(p.WebIdentityTokenProcess)
 
 	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...)
 	cmd.Env = os.Environ()

--- a/vault/config.go
+++ b/vault/config.go
@@ -72,7 +72,13 @@ func createConfigFilesIfMissing() error {
 			log.Printf("Config file %s not created", file)
 			return err
 		}
-		newFile.Close()
+
+		err = newFile.Close()
+		if err != nil {
+			log.Printf("Failed to write config file to %s", file)
+			return err
+		}
+
 		log.Printf("Config file %s created", file)
 	}
 	return nil


### PR DESCRIPTION
## What's here:
* Prevent MFA prompts on windows command overwrite from local directory. see [Command PATH security in Go - Are your own programs affected?](https://blog.golang.org/path-security#TOC_6.)
* Prevent potential command injection in OSAScript prompt - sanitize user input to `osascript -e`.
* Remove shellExpansion from assumerolewithwebidentity.
* Error handling for config file write to disk failure - gosec G104 errors not checked.
* Readme note on write protecting aws config files to prevent unintentional code execution.

## Impact
These changes should improve aws-vaults's security posture. We identified these vulnerabilities using [Salus](https://github.com/coinbase/salus) and the [OSSF scorecard](https://github.com/ossf/scorecard). The specific issues I am hoping to address here are:
- Gosec G104 Audit errors not checked
- Gosec G204 Audit use of command execution - Unintentional code execution.